### PR TITLE
Fix Postgres bug

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -43,6 +43,7 @@ export function OpenDb(configOriginal: DbConfig): DbCon | null {
       const config = configOriginal as PostgresDbConfig;
       try {
         const db = new Client();
+        db.connect();
         return {
           db,
           driver: DbDriver.Postgres,

--- a/tests/endToEndTest.ts
+++ b/tests/endToEndTest.ts
@@ -49,7 +49,7 @@ export async function testPostgresEndToEnd() {
       sql: "select * from testTable limit 5",
       message
     }));
-  }, 100);
+  }, 500);
   client.on("message", (message: string) => {
     clientLog(`message\n---------\n${JSON.stringify(message)}\n--------\n`);
     const parsedMessage = JSON.parse(message);


### PR DESCRIPTION
Turns out the `db.connect` was missing, and things appear to work now.
Not being familiar with Javascript, the example code is of the form `await db.connect()`, but this seems to work without the `await`?

I also needed to change the timeout so it connects with a remote server.